### PR TITLE
build(generator): update to allow for orphans/siblings

### DIFF
--- a/config/generator-config/feature.plop.ts
+++ b/config/generator-config/feature.plop.ts
@@ -1,4 +1,6 @@
-import { validateFilename } from "./utilities"
+import * as path from 'path'
+import * as fs from 'fs'
+import { validateFilename, detectComponentStructure } from "./utilities"
 import type { PlopTypes } from "@turbo/gen"
 
 type FeatureAnswers = {
@@ -6,23 +8,73 @@ type FeatureAnswers = {
   componentSubs: string
   stateName: string
   includeUiHook: boolean
+  createParentAnyway?: boolean
 }
 
 export const featurePlop: PlopTypes.PlopGeneratorConfig = {
   description: "Feature (component + state, wired)",
   prompts: async (inquirer) => {
-    const { componentMain } = await inquirer.prompt({
+    // First prompt for component name
+    const { componentMain: rawInput } = await inquirer.prompt({
       type: "input",
       name: "componentMain",
       message: "What is the component name?",
       validate: validateFilename,
     })
 
+    // Detect component structure
+    const componentsPath = path.join(process.cwd(), 'ui', 'components')
+    const detected = detectComponentStructure(rawInput, componentsPath)
+
+    let componentMain = rawInput
+    let autoDetectedSub = ''
+
+    // If we detected siblings (and no parent), confirm
+    if (detected.hasSiblings && !detected.hasParent) {
+      const siblingsList = detected.siblings.join(', ')
+      const { confirmDetection } = await inquirer.prompt({
+        type: 'confirm',
+        name: 'confirmDetection',
+        message: `Detected "${rawInput}" as a sub-component of "${detected.main}" family (found: ${siblingsList}). Correct?`,
+        default: true
+      })
+
+      if (confirmDetection) {
+        componentMain = detected.main
+        autoDetectedSub = detected.sub || ''
+      }
+    }
+
+    // Create a parent for an existing sibling-only family
+    let createParentAnyway = false
+    if (!componentMain.includes('-')) {
+      // Check if siblings exist
+      const allComponents = fs.readdirSync(componentsPath, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => dirent.name)
+        .filter(name => !name.startsWith('.') && !name.startsWith('_'))
+
+      const siblings = allComponents.filter(name => name.startsWith(componentMain + '-'))
+
+      if (siblings.length > 0 && !fs.existsSync(path.join(componentsPath, componentMain))) {
+        const siblingsList = siblings.join(', ')
+        const { confirmCreateParent } = await inquirer.prompt({
+          type: 'confirm',
+          name: 'confirmCreateParent',
+          message: `Found existing siblings (${siblingsList}). Create parent component '${componentMain}' anyway?`,
+          default: false
+        })
+        createParentAnyway = confirmCreateParent
+      }
+    }
+
+    // Prompt for additional subs (pre-fill with detected sub if any)
     const { componentSubs } = await inquirer.prompt({
       type: "input",
       name: "componentSubs",
       message:
         "What sub-components would you like? (comma separated, blank for none)",
+      default: autoDetectedSub,
       validate: (input: string) => {
         if (input.length === 0) return true
         const subs = input.split(",").map((s) => s.trim()).filter(Boolean)
@@ -52,6 +104,7 @@ export const featurePlop: PlopTypes.PlopGeneratorConfig = {
       componentSubs,
       stateName,
       includeUiHook,
+      createParentAnyway,
     })
   },
 
@@ -69,39 +122,57 @@ export const featurePlop: PlopTypes.PlopGeneratorConfig = {
       templateFiles: ["data-state/index.ts.hbs", "data-state/types.ts.hbs"],
     })
 
-    // 2) Main component (wired to state via template conditionals)
-    actions.push({
-      type: "addMany",
-      skipIfExists: true,
-      destination: "{{ turbo.paths.root }}/ui/components/{{ componentName }}/",
-      data: {
-        componentName: data.componentMain,
-        storyName: "Complete",
-        stateName: data.stateName,
-        includeUiHook: data.includeUiHook,
-        includeState: true,
-      },
-      templateFiles: [
-        "ui-component/component.story.tsx.hbs",
-        "ui-component/component.test.tsx.hbs",
-        "ui-component/index.tsx.hbs",
-        "ui-component/style.module.css.hbs",
-      ],
-    })
+    // Check if this is a sibling-only family (siblings exist but no parent)
+    const componentsPath = path.join(process.cwd(), 'ui', 'components')
+    const mainComponentPath = path.join(componentsPath, data.componentMain)
+    const mainExists = fs.existsSync(mainComponentPath)
 
-    // 3) Optional colocated hook (next to main component)
-    if (data.includeUiHook) {
+    // Check if siblings exist for this component family by looking for any folder that starts with componentMain-
+    let hasSiblings = false
+    if (fs.existsSync(componentsPath)) {
+      const allComponents = fs.readdirSync(componentsPath, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => dirent.name)
+        .filter(name => !name.startsWith('.') && !name.startsWith('_'))
+
+      hasSiblings = allComponents.some(name => name.startsWith(data.componentMain + '-'))
+    }
+
+    // 2) Main component (only if it doesn't exist AND (no siblings exist OR we confirmed to create parent anyway))
+    if (!mainExists && (!hasSiblings || data.createParentAnyway)) {
       actions.push({
-        type: "add",
+        type: "addMany",
         skipIfExists: true,
-        path:
-          "{{ turbo.paths.root }}/ui/components/{{ componentName }}/use{{pascalCase componentName}}Display.ts",
+        destination: "{{ turbo.paths.root }}/ui/components/{{ componentName }}/",
         data: {
           componentName: data.componentMain,
+          storyName: "Complete",
           stateName: data.stateName,
+          includeUiHook: data.includeUiHook,
+          includeState: true,
         },
-        templateFile: "ui-component/hook.ts.hbs",
+        templateFiles: [
+          "ui-component/component.story.tsx.hbs",
+          "ui-component/component.test.tsx.hbs",
+          "ui-component/index.tsx.hbs",
+          "ui-component/style.module.css.hbs",
+        ],
       })
+
+      // 3) Optional colocated hook (only if main component is created)
+      if (data.includeUiHook) {
+        actions.push({
+          type: "add",
+          skipIfExists: true,
+          path:
+            "{{ turbo.paths.root }}/ui/components/{{ componentName }}/use{{pascalCase componentName}}Display.ts",
+          data: {
+            componentName: data.componentMain,
+            stateName: data.stateName,
+          },
+          templateFile: "ui-component/hook.ts.hbs",
+        })
+      }
     }
 
     // 4) Sub-components (no automatic state wiring)

--- a/config/generator-config/ui-component/_plop.ts
+++ b/config/generator-config/ui-component/_plop.ts
@@ -1,28 +1,78 @@
-import { validateFilename } from '../utilities'
+import * as path from 'path'
+import * as fs from 'fs'
+import { validateFilename, detectComponentStructure } from '../utilities'
 import type { PlopTypes } from '@turbo/gen'
 
 type UIAnswers = {
   componentMain: string
   componentSubs: string
+  createParentAnyway?: boolean
 }
 
 export const uiPlop: PlopTypes.PlopGeneratorConfig = {
   description: 'Static UI Component',
   prompts: async (inquirer) => {
-    // Asking some questions
-    const { componentMain } = await inquirer.prompt({
+    // First prompt for component name
+    const { componentMain: rawInput } = await inquirer.prompt({
       type: 'input',
       name: 'componentMain',
       message: 'What is the component type?',
       validate: validateFilename
     })
 
+    // Detect component structure
+    const componentsPath = path.join(process.cwd(), 'ui', 'components')
+    const detected = detectComponentStructure(rawInput, componentsPath)
+
+    let componentMain = rawInput
+    let autoDetectedSub = ''
+
+    // If we detected siblings (and no parent), confirm what behavior we want
+    if (detected.hasSiblings && !detected.hasParent) {
+      const siblingsList = detected.siblings.join(', ')
+      const { confirmDetection } = await inquirer.prompt({
+        type: 'confirm',
+        name: 'confirmDetection',
+        message: `Detected "${rawInput}" as a sub-component of "${detected.main}" family (found: ${siblingsList}). Correct?`,
+        default: true
+      })
+
+      if (confirmDetection) {
+        componentMain = detected.main
+        autoDetectedSub = detected.sub || ''
+      }
+    }
+
+    // Create a parent for an existing sibling-only family
+    let createParentAnyway = false
+    if (!componentMain.includes('-')) {
+      // Check if siblings exist
+      const allComponents = fs.readdirSync(componentsPath, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => dirent.name)
+        .filter(name => !name.startsWith('.') && !name.startsWith('_'))
+
+      const siblings = allComponents.filter(name => name.startsWith(componentMain + '-'))
+
+      if (siblings.length > 0 && !fs.existsSync(path.join(componentsPath, componentMain))) {
+        const siblingsList = siblings.join(', ')
+        const { confirmCreateParent } = await inquirer.prompt({
+          type: 'confirm',
+          name: 'confirmCreateParent',
+          message: `Found existing siblings (${siblingsList}). Create parent component '${componentMain}' anyway?`,
+          default: false
+        })
+        createParentAnyway = confirmCreateParent
+      }
+    }
+
+    // Prompt for additional subs (pre-fill with detected sub if any)
     const { componentSubs } = await inquirer.prompt({
       type: 'input',
       name: 'componentSubs',
       message: 'What sub-components would you like? (comma separated, blank for none)',
+      default: autoDetectedSub,
       validate: (input: string) => {
-        // Blank condition
         if (input.length == 0) return true
         const subs = input.split(',').map((stringValue) => stringValue.toString().trim())
         const validatedValues = subs.map(validateFilename)
@@ -34,28 +84,52 @@ export const uiPlop: PlopTypes.PlopGeneratorConfig = {
     })
 
     return Promise.resolve({
-      // all answer
       componentSubs,
-      componentMain
+      componentMain,
+      createParentAnyway
     })
   },
   actions: function (data: UIAnswers) {
-    const { componentMain, componentSubs } = data
-    const addMain = {
-      type: 'addMany',
-      skipIfExists: true,
-      destination: '{{ turbo.paths.root }}/ui/components/{{ componentName }}/',
-      data: {
-        componentName: componentMain,
-        storyName: 'Complete'
-      },
-      templateFiles: [
-        'ui-component/component.story.tsx.hbs',
-        'ui-component/component.test.tsx.hbs',
-        'ui-component/index.tsx.hbs',
-        'ui-component/style.module.css.hbs'
-      ]
+    const { componentMain, componentSubs, createParentAnyway } = data
+    const actions: PlopTypes.ActionType[] = []
+
+    // Check if this is a sibling-only family (siblings exist but no parent)
+    const componentsPath = path.join(process.cwd(), 'ui', 'components')
+    const mainComponentPath = path.join(componentsPath, componentMain)
+    const mainExists = fs.existsSync(mainComponentPath)
+
+    // Check if siblings exist for this component family by looking for any folder that starts with componentMain-
+    let hasSiblings = false
+    if (fs.existsSync(componentsPath)) {
+      const allComponents = fs.readdirSync(componentsPath, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => dirent.name)
+        .filter(name => !name.startsWith('.') && !name.startsWith('_'))
+
+      hasSiblings = allComponents.some(name => name.startsWith(componentMain + '-'))
     }
+
+    // Only add main if it doesn't exist AND (no siblings exist OR user confirmed to create parent anyway)
+    if (!mainExists && (!hasSiblings || createParentAnyway)) {
+      const addMain = {
+        type: 'addMany',
+        skipIfExists: true,
+        destination: '{{ turbo.paths.root }}/ui/components/{{ componentName }}/',
+        data: {
+          componentName: componentMain,
+          storyName: 'Complete'
+        },
+        templateFiles: [
+          'ui-component/component.story.tsx.hbs',
+          'ui-component/component.test.tsx.hbs',
+          'ui-component/index.tsx.hbs',
+          'ui-component/style.module.css.hbs'
+        ]
+      }
+      actions.push(addMain)
+    }
+
+    // Add sub-components
     const subs = componentSubs
       .split(',')
       .filter(Boolean)
@@ -66,7 +140,7 @@ export const uiPlop: PlopTypes.PlopGeneratorConfig = {
           destination: '{{ turbo.paths.root }}/ui/components/{{ componentName }}/',
           data: {
             componentName,
-            storyName: subName
+            storyName: subName.trim()
           },
           templateFiles: [
             'ui-component/component.story.tsx.hbs',
@@ -77,6 +151,6 @@ export const uiPlop: PlopTypes.PlopGeneratorConfig = {
         }
       })
 
-    return [addMain, ...subs]
+    return [...actions, ...subs]
   }
 }

--- a/config/generator-config/utilities.ts
+++ b/config/generator-config/utilities.ts
@@ -1,3 +1,63 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+export interface ComponentStructure {
+  main: string
+  sub: string | null
+  hasSiblings: boolean
+  hasParent: boolean
+  siblings: string[]
+}
+
+export function detectComponentStructure(
+  input: string,
+  componentsPath: string
+): ComponentStructure {
+  // If no hyphen, it's a main component
+  if (!input.includes('-')) {
+    return {
+      main: input,
+      sub: null,
+      hasSiblings: false,
+      hasParent: false,
+      siblings: []
+    }
+  }
+
+  // Split on first hyphen only
+  const firstHyphenIndex = input.indexOf('-')
+  const prefix = input.substring(0, firstHyphenIndex)
+  const suffix = input.substring(firstHyphenIndex + 1)
+
+  // Check if parent folder exists
+  const parentPath = path.join(componentsPath, prefix)
+  const hasParent = fs.existsSync(parentPath) && fs.statSync(parentPath).isDirectory()
+
+  // Get all component folders
+  let allComponents: string[] = []
+  if (fs.existsSync(componentsPath)) {
+    allComponents = fs.readdirSync(componentsPath, { withFileTypes: true })
+      .filter(dirent => dirent.isDirectory())
+      .map(dirent => dirent.name)
+      .filter(name => !name.startsWith('.') && !name.startsWith('_'))
+  }
+
+  // Find siblings with same prefix (excluding current input)
+  const siblings = allComponents.filter(name =>
+    name !== input && name.startsWith(prefix + '-')
+  )
+
+  const hasSiblings = siblings.length > 0
+
+  return {
+    main: prefix,
+    sub: suffix,
+    hasSiblings,
+    hasParent,
+    siblings
+  }
+}
+
 export function validateFilename(input: string) {
   if (input.includes(".")) return "name cannot include an extension"
   if (input.includes("_")) return "name cannot include underscores"


### PR DESCRIPTION
Updating generator to allow for siblings of orphans... 

Basically, if I want to add something like discover-briefing, but discover-card already exists, I don't want to be required to say parent: discover, sub: briefing.

This adds a utility to check for siblings first and ask for some confirmations.  That way you don't get wonky storybooks.